### PR TITLE
Fix submodule update "permission denied" error

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "lib/lzw"]
 	path = lib/lzw
-	url = git@github.com:Mototroller/ax.lzw.git
+	url = https://github.com/Mototroller/ax.lzw.git


### PR DESCRIPTION
I tried pulling from this repo to see if it'll work, but I kept getting a `Permission denied (publickey)` error whenever I do `git submodule update`. To fix this, I edited `.gitmodules` to use the HTTPS link instead.